### PR TITLE
feat: add LanguageSelector component to select language from supported locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 i18next components to help translate [astro](https://astro.build/) websites.
 
-> **Status**
+> **Status** [alpha version]
 >
-> Currently in development: missing tests, better docs and examples
+> Currently in development, not ready yet! Missing tests, better integration,
+> better docs and examples
 
 ## Install
 
@@ -35,17 +36,35 @@ import { Trans } from "astro-i18next";
 ```
 
 ```json
-// en.json
+// fr.json
 {
-  "superCoolKey": "This is a <0>super cool</0> sentence!"
+  "superCoolKey": "Ceci est une phrase <0>super cool</0>!"
 }
 ```
 
-### Props
+#### Trans Props
 
 | Propname | Type   | Description              |
 | -------- | ------ | ------------------------ |
 | i18nKey  | string | Internationalization key |
+
+### LanguageSelector component
+
+Unstyled custom select component to choose amongst supported locales.
+
+```astro
+---
+import { LanguageSelector } from "astro-i18next";
+---
+
+<LanguageSelector className="my-select-class" />
+```
+
+#### LanguageSelector Props
+
+| Propname  | Type   | Description                            |
+| --------- | ------ | -------------------------------------- |
+| className | string | class attribute for the `<select>` tag |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "astro-i18next",
       "version": "1.0.0-alpha.1",
       "license": "MIT",
+      "dependencies": {
+        "i18next": "^21.6.16",
+        "iso-639-1": "^2.1.13"
+      },
       "devDependencies": {
         "@commitlint/cli": "^16.2.4",
         "@commitlint/config-conventional": "^16.2.4",
@@ -36,8 +40,7 @@
         "typescript": "^4.6.4"
       },
       "peerDependencies": {
-        "astro": "^1.0.0-beta.1",
-        "i18next": "^21.0.0"
+        "astro": "^1.0.0-beta.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8339,6 +8342,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/iso-639-1": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.13.tgz",
+      "integrity": "sha512-stYt3u6OnVDNcK4IWARGXmTOOY5Wa5g4bUmBsttZp/55ZiEjDUibR3C59ZnorKoSS0tfJmFuGMST3ksnY1zu7Q==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/issue-parser": {
       "version": "6.0.0",
@@ -23893,6 +23904,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "iso-639-1": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-2.1.13.tgz",
+      "integrity": "sha512-stYt3u6OnVDNcK4IWARGXmTOOY5Wa5g4bUmBsttZp/55ZiEjDUibR3C59ZnorKoSS0tfJmFuGMST3ksnY1zu7Q=="
     },
     "issue-parser": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "astro": "^1.0.0-beta.1"
   },
   "dependencies": {
-    "i18next": "^21.6.16"
+    "i18next": "^21.6.16",
+    "iso-639-1": "^2.1.13"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.4",

--- a/src/LanguageSelector.astro
+++ b/src/LanguageSelector.astro
@@ -1,0 +1,26 @@
+---
+import i18next from "i18next";
+import ISO6391 from "iso-639-1";
+
+export interface Props {
+  className?: string;
+}
+
+const supportedLanguages = i18next.languages;
+const currentLanguage = i18next.language;
+
+const { className } = Astro.props;
+---
+
+<select onchange="location = this.value;" class={className}>
+  {supportedLanguages.map((supportedLanguage: string) => {
+    const value = supportedLanguage === "en" ? "/" : supportedLanguage
+    const label = ISO6391.getNativeName(supportedLanguage)
+
+    return (
+      <option value={value} selected={supportedLanguage === currentLanguage}>
+        {label}
+      </option>
+    )
+  })}
+</select>

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,1 +1,2 @@
 export { default as Trans } from "./Trans.astro";
+export { default as LanguageSelector } from "./LanguageSelector.astro";


### PR DESCRIPTION
Use `iso-639-1` library to get native language name from language code.