### PR TITLE
fix: type definitions for exported astro components

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,18 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
-    "./components": "./dist/components/index.d.mts"
+    "./components": "./dist/components/index.js"
   },
+	"typesVersions": {
+		"*": {
+			"index": [
+				"./dist/index.d.ts"
+			],
+			"components": [
+				"./dist/components/index.d.mts"
+			]
+		}
+	},
   "bin": {
     "astro-i18next": "./dist/cli/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
     ".": "./dist/index.js",
     "./components": "./dist/components/index.js"
   },
-	"typesVersions": {
-		"*": {
-			"index": [
-				"./dist/index.d.ts"
-			],
-			"components": [
-				"./dist/components/index.d.mts"
-			]
-		}
-	},
+  "typesVersions": {
+    "*": {
+      "index": [
+        "./dist/index.d.ts"
+      ],
+      "components": [
+        "./dist/components/index.d.mts"
+      ]
+    }
+  },
   "bin": {
     "astro-i18next": "./dist/cli/index.js"
   },


### PR DESCRIPTION
I have the same problem as #18 

These changes work fine for me.

