### PR TITLE
docs: include missing i18next import to quick tutorial in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Here's a quick tutorial to get you going:
    ```astro
    ---
    // src/pages/index.astro
-   import { t } from "i18next";
+   import i18next, { t } from "i18next";
    import { Trans, HeadHrefLangs } from "astro-i18next/components";
    ---
 


### PR DESCRIPTION
the i18next is being used and needed in the import
<html lang={i18next.language}>