### PR TITLE
fix: Rollup failed to resolve import 'types'

### DIFF
--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,4 +1,4 @@
-import { AstroI18nextConfig } from "types";
+import { AstroI18nextConfig } from "../types";
 
 export interface GlobalArgs {
   verbose: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { AstroIntegration } from "astro";
-import { AstroI18nextConfig, AstroI18nextOptions } from "types";
+import { AstroI18nextConfig, AstroI18nextOptions } from "./types";
 import {
   moveBaseLanguageToFirstIndex,
   deeplyStringifyObject,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import i18next, { t } from "i18next";
 import { fileURLToPath } from "url";
 import load from "@proload/core";
-import { AstroI18nextConfig } from "types";
+import { AstroI18nextConfig } from "./types";
 import typescript from "@proload/plugin-typescript";
 
 /**


### PR DESCRIPTION
Without this, it causes the following error on node 16 @ `astro build`:

```
[vite]: Rollup failed to resolve import "types" from "node_modules/astro-i18next/src/utils.ts".
This is most likely unintended because it can break your application at runtime
```

Having a fairly simple setup:

astro-i18next.config.mjs
```
const config = {
  defaultLanguage: "de",
  supportedLanguages: ["en", "de"],
  i18next: {
    initImmediate: false,
    backend: {
      loadPath: "./src/locales/{{lng}}.json",
    },
  },
  i18nextPlugins: { fsBackend: "i18next-fs-backend" },
};

export default config;

```

astro.config.mjs
```
import { defineConfig } from 'astro/config'
import vue from '@astrojs/vue'
import astroI18next from 'astro-i18next'

// https://astro.build/config
export default defineConfig({
  integrations: [vue(), astroI18next()]
})

```