### PR TITLE
feat: added support for route translations

### DIFF
--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { AstroI18nextConfig } from "types";
 import {
   getAstroPagesPath,
   createFiles,
@@ -6,6 +7,7 @@ import {
   generateLocalizedFrontmatter,
   overwriteAstroFrontmatter,
   parseFrontmatter,
+  createTranslatedPath,
 } from "./utils";
 
 /**
@@ -17,8 +19,9 @@ import {
  */
 export const generate = (
   inputPath: string,
-  defaultLanguage: string,
-  supportedLanguages: string[],
+  defaultLanguage: AstroI18nextConfig["defaultLanguage"],
+  supportedLanguages: AstroI18nextConfig["supportedLanguages"],
+  routeTranslations?: AstroI18nextConfig["routes"],
   outputPath: string = inputPath
 ): { filesToGenerate: FileToGenerate[]; timeToProcess: number } => {
   const start = process.hrtime();
@@ -48,9 +51,12 @@ export const generate = (
       );
 
       filesToGenerate.push({
-        path: [outputPath, language === defaultLanguage ? null : language, file]
-          .filter(Boolean)
-          .join("/"),
+        path: createTranslatedPath(
+          routeTranslations,
+          file,
+          language === defaultLanguage ? undefined : language,
+          outputPath
+        ),
         source: newFileContents,
       });
     });

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -52,10 +52,10 @@ export const generate = (
 
       filesToGenerate.push({
         path: createTranslatedPath(
-          routeTranslations,
           file,
           language === defaultLanguage ? undefined : language,
-          outputPath
+          outputPath,
+          routeTranslations
         ),
         source: newFileContents,
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ yargs(hideBin(process.argv))
         pagesPath,
         argv.config.defaultLanguage,
         argv.config.supportedLanguages,
+        argv.config.routes,
         argv.output
       );
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -147,12 +147,13 @@ export const createFiles = (filesToGenerate: FileToGenerate[]): void => {
  * @param base defaults to `""`.
  */
 export const createTranslatedPath = (
-  routeTranslations: AstroI18nextConfig["routes"],
   path: string,
   lang?: string,
-  base = ""
+  base = "",
+  routeTranslations: AstroI18nextConfig["routes"] = {}
 ) => {
-  if (!lang || !routeTranslations[lang]) return `${base}/${path}`;
+  if (!lang) return `${base}/${path}`;
+  if (!routeTranslations[lang]) return `${base}/${lang}/${path}`;
   return `${base}/${lang}/${path
     .split("/")
     .map((segment) => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -143,21 +143,22 @@ export const createFiles = (filesToGenerate: FileToGenerate[]): void => {
 
 /**
  * Translates `path` with `routeTranslations` if `lang` exists in
- * `routeTranslations`, else returns `[base, path].join("/")`.
- * @param base defaults to `""`.
+ * `routeTranslations`, else returns `[basePath, path].join("/")` or
+ * `[basePath, language, path].join("/")`.
+ * @param basePath defaults to `""`.
  */
 export const createTranslatedPath = (
   path: string,
-  lang?: string,
-  base = "",
+  language?: string,
+  basePath = "",
   routeTranslations: AstroI18nextConfig["routes"] = {}
 ) => {
-  if (!lang) return `${base}/${path}`;
-  if (!routeTranslations[lang]) return `${base}/${lang}/${path}`;
-  return `${base}/${lang}/${path
+  if (!language) return `${basePath}/${path}`;
+  if (!routeTranslations[language]) return `${basePath}/${language}/${path}`;
+  return `${basePath}/${language}/${path
     .split("/")
     .map((segment) => {
-      const translated = routeTranslations[lang][segment];
+      const translated = routeTranslations[language][segment];
       if (!translated) return segment;
       return translated;
     })

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -6,6 +6,7 @@ import path from "path";
 import fs from "fs";
 import ts from "typescript";
 import { transformer } from "./transformer";
+import { AstroI18nextConfig } from "types";
 
 export interface FileToGenerate {
   path: string;
@@ -138,5 +139,27 @@ export const createFiles = (filesToGenerate: FileToGenerate[]): void => {
 
     fs.writeFileSync(fileToGenerate.path, fileToGenerate.source);
   });
+};
+
+/**
+ * Translates `path` with `routeTranslations` if `lang` exists in
+ * `routeTranslations`, else returns `[base, path].join("/")`.
+ * @param base defaults to `""`.
+ */
+export const createTranslatedPath = (
+  routeTranslations: AstroI18nextConfig["routes"],
+  path: string,
+  lang?: string,
+  base = ""
+) => {
+  if (!lang || !routeTranslations[lang]) return `${base}/${path}`;
+  return `${base}/${lang}/${path
+    .split("/")
+    .map((segment) => {
+      const translated = routeTranslations[lang][segment];
+      if (!translated) return segment;
+      return translated;
+    })
+    .join("/")}`;
 };
 /* c8 ignore stop */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const I18NEXT_ROUTES_BUNDLE_NS = "astroI18nextConfig.routes";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   moveBaseLanguageToFirstIndex,
   deeplyStringifyObject,
   getUserConfig,
+  createResourceBundleCallback,
 } from "./utils";
 
 export default (options?: AstroI18nextOptions): AstroIntegration => {
@@ -94,7 +95,7 @@ export default (options?: AstroI18nextOptions): AstroIntegration => {
         }
         i18nextInit += `.init(${deeplyStringifyObject(
           astroI18nextConfig.i18next
-        )});`;
+        )}, ${createResourceBundleCallback(astroI18nextConfig.routes)});`;
 
         injectScript("page-ssr", imports + i18nextInit);
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,4 +44,9 @@ export interface AstroI18nextConfig {
   i18nextPlugins?: {
     [key: string]: string;
   };
+
+  routes: {
+    // eslint-disable-next-line no-unused-vars
+    [lang: string]: Record<string, string>;
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,8 +45,12 @@ export interface AstroI18nextConfig {
     [key: string]: string;
   };
 
+  /**
+   * The translations for your routes.
+   *
+   * @default undefined
+   */
   routes: {
-    // eslint-disable-next-line no-unused-vars
-    [lang: string]: Record<string, string>;
+    [language: string]: Record<string, string>;
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
-import i18next, { t } from "i18next";
+import i18next, { type i18n, t } from "i18next";
 import { fileURLToPath } from "url";
 import load from "@proload/core";
 import { AstroI18nextConfig } from "./types";
 import typescript from "@proload/plugin-tsm";
+import { I18NEXT_ROUTES_BUNDLE_NS } from "./constants";
 
 /**
  * Adapted from astro's tailwind integration:
@@ -150,6 +151,12 @@ export const localizePath = (
     }
   }
 
+  // translating pathSegments
+  const routeTranslations = getLanguageRouteTranslations(i18next, locale);
+  pathSegments = pathSegments.map((segment) =>
+    routeTranslations[segment] ? routeTranslations[segment] : segment
+  );
+
   // prepend the given locale if it's not the base one
   if (locale !== i18next.options.supportedLngs[0]) {
     pathSegments = [locale, ...pathSegments];
@@ -246,4 +253,22 @@ export const deeplyStringifyObject = (obj: object | Array<any>): string => {
     str += isArray ? `${value},` : `"${key}": ${value},`;
   }
   return `${str}${isArray ? "]" : "}"}`;
+};
+
+export const createResourceBundleCallback = (
+  routes: AstroI18nextConfig["routes"]
+) => {
+  let callback = "() => {";
+  for (const lang in routes) {
+    callback += `i18next.addResourceBundle("${lang}", "${I18NEXT_ROUTES_BUNDLE_NS}", ${JSON.stringify(
+      routes[lang]
+    )});`;
+  }
+  return `${callback}}`;
+};
+
+export const getLanguageRouteTranslations = (i18next: i18n, lang: string) => {
+  return i18next.getResourceBundle(lang, I18NEXT_ROUTES_BUNDLE_NS) as
+    | AstroI18nextConfig["routes"][keyof AstroI18nextConfig["routes"]]
+    | undefined;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,7 +152,7 @@ export const localizePath = (
   }
 
   // translating pathSegments
-  const routeTranslations = getLanguageRouteTranslations(i18next, locale);
+  const routeTranslations = getLanguageRouteTranslations(i18next, locale) || {};
   pathSegments = pathSegments.map((segment) =>
     routeTranslations[segment] ? routeTranslations[segment] : segment
   );
@@ -256,7 +256,7 @@ export const deeplyStringifyObject = (obj: object | Array<any>): string => {
 };
 
 export const createResourceBundleCallback = (
-  routes: AstroI18nextConfig["routes"]
+  routes: AstroI18nextConfig["routes"] = {}
 ) => {
   let callback = "() => {";
   for (const lang in routes) {


### PR DESCRIPTION
#29 
- Added a new config property `routes`
- Added support for generating translated routes depending on config.routes
- Added support for translated `localizePath` depending on config.routes