### PR TITLE
feat: added support for showing the default locale in the url

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,6 +38,7 @@ yargs(hideBin(process.argv))
         pagesPath,
         argv.config.defaultLanguage,
         argv.config.supportedLanguages,
+        argv.config.showDefaultLocale,
         argv.config.routes,
         argv.output
       );

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -119,18 +119,28 @@ export const generateLocalizedFrontmatter = (
  * (https://docs.astro.build/en/core-concepts/routing/#excluding-pages)
  *
  * @param pagesDirectoryPath
+ * @param childDirToCrawl will make the function crawl inside the given
+ * `childDirToCrawl` (doesn't take paths, only dirname).
  */
-export const getAstroPagesPath = (pagesDirectoryPath: string): PathsOutput => {
+export const getAstroPagesPath = (
+  pagesDirectoryPath: string,
+  childDirToCrawl = undefined as
+    | AstroI18nextConfig["defaultLanguage"]
+    | undefined
+): PathsOutput => {
   // eslint-disable-next-line new-cap
   const api = new fdir()
     .filter(
       (filepath) => !isFileHidden(filepath) && filepath.endsWith(".astro")
     )
     .exclude((dirName) => isLocale(dirName))
-    .withRelativePaths()
-    .crawl(pagesDirectoryPath);
+    .withRelativePaths();
 
-  return api.sync() as PathsOutput;
+  return childDirToCrawl
+    ? (api
+        .crawl(`${pagesDirectoryPath}${path.sep}${childDirToCrawl}`)
+        .sync() as PathsOutput)
+    : (api.crawl(pagesDirectoryPath).sync() as PathsOutput);
 };
 
 export const createFiles = (filesToGenerate: FileToGenerate[]): void => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,16 @@
+import { AstroI18nextConfig } from "types";
+
+const astroI18nextConfig: AstroI18nextConfig = {
+  defaultLanguage: "cimode",
+  supportedLanguages: [],
+  routes: {},
+  showDefaultLocale: false,
+};
+
+export const getAstroI18nextConfig = () => astroI18nextConfig;
+
+export const setAstroI18nextConfig = (config: AstroI18nextConfig) => {
+  for (const key in config) {
+    astroI18nextConfig[key] = config[key];
+  }
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,0 @@
-export const I18NEXT_ROUTES_BUNDLE_NS = "astroI18nextConfig.routes";

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,9 +48,16 @@ export interface AstroI18nextConfig {
   /**
    * The translations for your routes.
    *
-   * @default undefined
+   * @default {}
    */
-  routes: {
+  routes?: {
     [language: string]: Record<string, string>;
   };
+
+  /**
+   * The display behaviour for the URL locale.
+   *
+   * @default false
+   */
+  showDefaultLocale?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import i18next, { type i18n, t } from "i18next";
+import i18next, { t } from "i18next";
 import { fileURLToPath } from "url";
 import load from "@proload/core";
 import { AstroI18nextConfig } from "./types";
 import typescript from "@proload/plugin-tsm";
-import { I18NEXT_ROUTES_BUNDLE_NS } from "./constants";
+import { getAstroI18nextConfig } from "./config";
 
 /**
  * Adapted from astro's tailwind integration:
@@ -127,38 +127,34 @@ export const localizePath = (
     return base + path;
   }
 
+  const { routes, showDefaultLocale } = getAstroI18nextConfig();
   let pathSegments = path.split("/");
 
   if (
     JSON.stringify(pathSegments) === JSON.stringify([""]) ||
     JSON.stringify(pathSegments) === JSON.stringify(["", ""])
   ) {
+    if (showDefaultLocale) return `${base}${locale}/`;
     return locale === i18next.options.supportedLngs[0]
       ? base
       : `${base}${locale}/`;
   }
 
-  // make a copy of i18next's supportedLngs
-  const otherLocales = [...(i18next.options.supportedLngs as string[])];
-  otherLocales.slice(1); // remove base locale (first index)
-
-  // loop over all locales except the base one
-  for (const otherLocale of otherLocales) {
-    if (pathSegments[0] === otherLocale) {
-      // if the path starts with one of the other locales, remove it from the path
+  // remove locale from pathSegments (if there is any)
+  for (const locale of i18next.options.supportedLngs as string[]) {
+    if (pathSegments[0] === locale) {
       pathSegments.shift();
-      break; // no need to continue
+      break;
     }
   }
 
   // translating pathSegments
-  const routeTranslations = getLanguageRouteTranslations(i18next, locale) || {};
   pathSegments = pathSegments.map((segment) =>
-    routeTranslations[segment] ? routeTranslations[segment] : segment
+    routes[locale]?.[segment] ? routes[locale][segment] : segment
   );
 
-  // prepend the given locale if it's not the base one
-  if (locale !== i18next.options.supportedLngs[0]) {
+  // prepend the given locale if it's not the base one (unless showDefaultLocale)
+  if (showDefaultLocale || locale !== i18next.options.supportedLngs[0]) {
     pathSegments = [locale, ...pathSegments];
   }
 
@@ -253,22 +249,4 @@ export const deeplyStringifyObject = (obj: object | Array<any>): string => {
     str += isArray ? `${value},` : `"${key}": ${value},`;
   }
   return `${str}${isArray ? "]" : "}"}`;
-};
-
-export const createResourceBundleCallback = (
-  routes: AstroI18nextConfig["routes"] = {}
-) => {
-  let callback = "() => {";
-  for (const lang in routes) {
-    callback += `i18next.addResourceBundle("${lang}", "${I18NEXT_ROUTES_BUNDLE_NS}", ${JSON.stringify(
-      routes[lang]
-    )});`;
-  }
-  return `${callback}}`;
-};
-
-export const getLanguageRouteTranslations = (i18next: i18n, lang: string) => {
-  return i18next.getResourceBundle(lang, I18NEXT_ROUTES_BUNDLE_NS) as
-    | AstroI18nextConfig["routes"][keyof AstroI18nextConfig["routes"]]
-    | undefined;
 };


### PR DESCRIPTION
- added a property to the `astro-i18next` config `showDefaultLocale`, to set the behaviour of the routing concerning the default locale (`localizePath` & `generate`)
- added a better way to use the `astro-i18next` config in the runtime (made the necessary modifications for the config's `routes` property to use this new way)