### PR TITLE
refactor: move getUserConfig to cli utils

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -3,7 +3,7 @@
 require("esbuild")
   .build({
     bundle: true,
-    entryPoints: ["src/index.ts", "src/cli/index.ts"],
+    entryPoints: ["src/index.ts", "src/utils.ts", "src/cli/index.ts"],
     outdir: "dist",
     external: [
       "i18next",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
       "index": [
         "./dist/types/index.d.ts"
       ],
+      "utils": [
+        "./dist/types/utils.d.ts"
+      ],
       "components": [
         "./src/components/index.d.ts"
       ]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./utils": "./dist/utils.js",
     "./components": "./src/components/index.ts"
   },
   "typesVersions": {

--- a/src/__tests__/pluginUtils.test.ts
+++ b/src/__tests__/pluginUtils.test.ts
@@ -1,0 +1,148 @@
+import {
+  moveBaseLanguageToFirstIndex,
+  deeplyStringifyObject,
+} from "../pluginUtils";
+import i18next from "i18next";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// init i18next config with "en", "fr", "fr-CA" and "es" as supported languages,
+// and "en" being the base language
+i18next.init({
+  lng: "en",
+  debug: false,
+  supportedLngs: ["en", "fr", "es", "fr-CA"], // ℹ️ base language is the first one, ie. "en"
+  fallbackLng: ["en", "fr", "es", "fr-CA"],
+  resources: {
+    en: {
+      translation: {
+        hello: "Hello!",
+        interpolationKey: "This is a <0>super cool</0> sentence!",
+        interpolationKeySelfClosing: "This has an image <0> here",
+        interpolationKeyNoHTML:
+          "This is a reference string without any HTML tags!",
+      },
+    },
+    fr: {
+      translation: {
+        hello: "Bonjour !",
+        interpolationKey: "Ceci est une phrase <0>super cool</0> !",
+        interpolationKeySelfClosing: "Ceci a une image <0> ici",
+        interpolationKeyNoHTML:
+          "Ceci est une chaîne de caractères de référence, sans aucune balise HTML !",
+      },
+    },
+  },
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("moveBaseLanguageToFirstIndex(...)", () => {
+  it("moves base language to first index", () => {
+    const supportedLngs = ["fr", "es", "en"];
+
+    moveBaseLanguageToFirstIndex(supportedLngs, "en");
+    expect(supportedLngs).toStrictEqual(["en", "fr", "es"]);
+  });
+
+  it("keeps base language in first index", () => {
+    const supportedLngs = ["fr", "es", "en"];
+
+    moveBaseLanguageToFirstIndex(supportedLngs, "fr");
+    expect(supportedLngs).toStrictEqual(["fr", "es", "en"]);
+  });
+});
+
+describe("deeplyStringifyObject(...)", () => {
+  it("with deep object", () => {
+    const objectToStringify = {
+      string1: "This is a string",
+      object1: {
+        string2: "This is another string",
+        string3: "This is yet another string",
+        function1: function () {
+          console.log("This is a function");
+        },
+        arrowFunction: () => {
+          console.log("This is an arrow function");
+        },
+        array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
+        object2: {
+          string4: "Again, another string!",
+        },
+        symbol1: Symbol("sym"),
+        nan1: NaN,
+        infinity1: Infinity,
+        negativeInfinity1: -Infinity,
+        undefined1: undefined,
+        null1: null,
+        boolean1: true,
+        boolean2: false,
+      },
+    };
+
+    expect(deeplyStringifyObject(objectToStringify)).toBe(
+      `{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},}`
+    );
+  });
+
+  it("with deep array", () => {
+    const arrayToStringify = [
+      {
+        string1: "This is a string",
+        object1: {
+          string2: "This is another string",
+          string3: "This is yet another string",
+          function1: function () {
+            console.log("This is a function");
+          },
+          arrowFunction: () => {
+            console.log("This is an arrow function");
+          },
+          array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
+          object2: {
+            string4: "Again, another string!",
+          },
+          symbol1: Symbol("sym"),
+          nan1: NaN,
+          infinity1: Infinity,
+          negativeInfinity1: -Infinity,
+          undefined1: undefined,
+          null1: null,
+          boolean1: true,
+          boolean2: false,
+        },
+      },
+      {
+        string1: "This is a string",
+        object1: {
+          string2: "This is another string",
+          string3: "This is yet another string",
+          function1: function () {
+            console.log("This is a function");
+          },
+          arrowFunction: () => {
+            console.log("This is an arrow function");
+          },
+          array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
+          object2: {
+            string4: "Again, another string!",
+          },
+          symbol1: Symbol("sym"),
+          nan1: NaN,
+          infinity1: Infinity,
+          negativeInfinity1: -Infinity,
+          undefined1: undefined,
+          null1: null,
+          boolean1: true,
+          boolean2: false,
+        },
+      },
+    ];
+
+    expect(deeplyStringifyObject(arrayToStringify)).toBe(
+      `[{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},},{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},},]`
+    );
+  });
+});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -2,9 +2,7 @@ import {
   interpolate,
   createReferenceStringFromHTML,
   localizePath,
-  moveBaseLanguageToFirstIndex,
   localizeUrl,
-  deeplyStringifyObject,
   detectLocaleFromPath,
 } from "../utils";
 import i18next from "i18next";
@@ -41,22 +39,6 @@ i18next.init({
 
 afterEach(() => {
   vi.clearAllMocks();
-});
-
-describe("moveBaseLanguageToFirstIndex(...)", () => {
-  it("moves base language to first index", () => {
-    const supportedLngs = ["fr", "es", "en"];
-
-    moveBaseLanguageToFirstIndex(supportedLngs, "en");
-    expect(supportedLngs).toStrictEqual(["en", "fr", "es"]);
-  });
-
-  it("keeps base language in first index", () => {
-    const supportedLngs = ["fr", "es", "en"];
-
-    moveBaseLanguageToFirstIndex(supportedLngs, "fr");
-    expect(supportedLngs).toStrictEqual(["fr", "es", "en"]);
-  });
 });
 
 describe("interpolate(...)", () => {
@@ -364,98 +346,5 @@ describe("detectLocaleFromPath(...)", () => {
   it("with unsupported locales", () => {
     expect(detectLocaleFromPath("/de/example")).toBe("en");
     expect(detectLocaleFromPath("de/example")).toBe("en");
-  });
-});
-
-describe("deeplyStringifyObject(...)", () => {
-  it("with deep object", () => {
-    const objectToStringify = {
-      string1: "This is a string",
-      object1: {
-        string2: "This is another string",
-        string3: "This is yet another string",
-        function1: function () {
-          console.log("This is a function");
-        },
-        arrowFunction: () => {
-          console.log("This is an arrow function");
-        },
-        array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
-        object2: {
-          string4: "Again, another string!",
-        },
-        symbol1: Symbol("sym"),
-        nan1: NaN,
-        infinity1: Infinity,
-        negativeInfinity1: -Infinity,
-        undefined1: undefined,
-        null1: null,
-        boolean1: true,
-        boolean2: false,
-      },
-    };
-
-    expect(deeplyStringifyObject(objectToStringify)).toBe(
-      `{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},}`
-    );
-  });
-
-  it("with deep array", () => {
-    const arrayToStringify = [
-      {
-        string1: "This is a string",
-        object1: {
-          string2: "This is another string",
-          string3: "This is yet another string",
-          function1: function () {
-            console.log("This is a function");
-          },
-          arrowFunction: () => {
-            console.log("This is an arrow function");
-          },
-          array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
-          object2: {
-            string4: "Again, another string!",
-          },
-          symbol1: Symbol("sym"),
-          nan1: NaN,
-          infinity1: Infinity,
-          negativeInfinity1: -Infinity,
-          undefined1: undefined,
-          null1: null,
-          boolean1: true,
-          boolean2: false,
-        },
-      },
-      {
-        string1: "This is a string",
-        object1: {
-          string2: "This is another string",
-          string3: "This is yet another string",
-          function1: function () {
-            console.log("This is a function");
-          },
-          arrowFunction: () => {
-            console.log("This is an arrow function");
-          },
-          array1: [12346, 55, "string", { foo: "foo", bar: "bar" }],
-          object2: {
-            string4: "Again, another string!",
-          },
-          symbol1: Symbol("sym"),
-          nan1: NaN,
-          infinity1: Infinity,
-          negativeInfinity1: -Infinity,
-          undefined1: undefined,
-          null1: null,
-          boolean1: true,
-          boolean2: false,
-        },
-      },
-    ];
-
-    expect(deeplyStringifyObject(arrayToStringify)).toBe(
-      `[{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},},{"string1": "This is a string","object1": {"string2": "This is another string","string3": "This is yet another string","function1": function() { console.log("This is a function"); },"arrowFunction": () => { console.log("This is an arrow function"); },"array1": [12346,55,"string",{"foo": "foo","bar": "bar",},],"object2": {"string4": "Again, another string!",},"symbol1": Symbol("sym"),"nan1": NaN,"infinity1": Infinity,"negativeInfinity1": -Infinity,"boolean1": true,"boolean2": false,},},]`
-    );
   });
 });

--- a/src/cli/middlewares.ts
+++ b/src/cli/middlewares.ts
@@ -1,6 +1,6 @@
 import { pathToFileURL } from "url";
 import { MiddlewareFunction } from "yargs";
-import { getUserConfig } from "../utils";
+import { getUserConfig } from "../pluginUtils";
 import { GenerateArgs, GlobalArgs } from "./types";
 
 // @ts-ignore

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -6,7 +6,7 @@ import path from "path";
 import fs from "fs";
 import ts from "typescript";
 import { transformer } from "./transformer";
-import { AstroI18nextConfig } from "types";
+import { AstroI18nextConfig } from "../types";
 
 export interface FileToGenerate {
   path: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   moveBaseLanguageToFirstIndex,
   deeplyStringifyObject,
   getUserConfig,
-} from "./utils";
+} from "./pluginUtils";
 
 export default (options?: AstroI18nextOptions): AstroIntegration => {
   const customConfigPath = options?.configPath;

--- a/src/pluginUtils.ts
+++ b/src/pluginUtils.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from "url";
+import load from "@proload/core";
+import { AstroI18nextConfig } from "./types";
+import typescript from "@proload/plugin-tsm";
+
+/**
+ * Moves the default locale in the first index
+ */
+export const moveBaseLanguageToFirstIndex = (
+  supportedLocales: string[],
+  baseLocale: string
+): void => {
+  const baseLocaleIndex = supportedLocales.indexOf(baseLocale);
+  supportedLocales.splice(baseLocaleIndex, 1);
+  supportedLocales.unshift(baseLocale);
+};
+
+export const deeplyStringifyObject = (obj: object | Array<any>): string => {
+  const isArray = Array.isArray(obj);
+  let str = isArray ? "[" : "{";
+  for (const key in obj) {
+    if (obj[key] === null || obj[key] === undefined) {
+      continue;
+    }
+
+    let value = null;
+
+    // see typeof result: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#description
+    switch (typeof obj[key]) {
+      case "string": {
+        value = `"${obj[key]}"`;
+        break;
+      }
+      case "number":
+      case "boolean": {
+        value = obj[key];
+        break;
+      }
+      case "object": {
+        value = deeplyStringifyObject(obj[key]);
+        break;
+      }
+      case "function": {
+        value = obj[key].toString().replace(/\s+/g, " ");
+        break;
+      }
+      case "symbol": {
+        value = `Symbol("${obj[key].description}")`;
+        break;
+      }
+      /* c8 ignore start */
+      default:
+        break;
+      /* c8 ignore stop */
+    }
+
+    str += isArray ? `${value},` : `"${key}": ${value},`;
+  }
+  return `${str}${isArray ? "]" : "}"}`;
+};
+
+/**
+ * Adapted from astro's tailwind integration:
+ * https://github.com/withastro/astro/tree/main/packages/integrations/tailwind
+ */
+/* c8 ignore start */
+export const getUserConfig = async (
+  root: URL,
+  configPath?: string
+): Promise<load.Config<AstroI18nextConfig>> => {
+  const resolvedRoot = fileURLToPath(root);
+  let userConfigPath: string | undefined;
+
+  if (configPath) {
+    const configPathWithLeadingSlash = /^\.*\//.test(configPath)
+      ? configPath
+      : `./${configPath}`;
+
+    userConfigPath = fileURLToPath(new URL(configPathWithLeadingSlash, root));
+  }
+
+  load.use([typescript]);
+  return (await load("astro-i18next", {
+    mustExist: false,
+    cwd: resolvedRoot,
+    filePath: userConfigPath,
+  })) as load.Config<AstroI18nextConfig>;
+};
+/* c8 ignore stop */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,50 +1,5 @@
 import i18next, { t } from "i18next";
-import { fileURLToPath } from "url";
-import load from "@proload/core";
-import { AstroI18nextConfig } from "./types";
-import typescript from "@proload/plugin-tsm";
 import { getAstroI18nextConfig } from "./config";
-
-/**
- * Adapted from astro's tailwind integration:
- * https://github.com/withastro/astro/tree/main/packages/integrations/tailwind
- */
-/* c8 ignore start */
-export const getUserConfig = async (
-  root: URL,
-  configPath?: string
-): Promise<load.Config<AstroI18nextConfig>> => {
-  const resolvedRoot = fileURLToPath(root);
-  let userConfigPath: string | undefined;
-
-  if (configPath) {
-    const configPathWithLeadingSlash = /^\.*\//.test(configPath)
-      ? configPath
-      : `./${configPath}`;
-
-    userConfigPath = fileURLToPath(new URL(configPathWithLeadingSlash, root));
-  }
-
-  load.use([typescript]);
-  return (await load("astro-i18next", {
-    mustExist: false,
-    cwd: resolvedRoot,
-    filePath: userConfigPath,
-  })) as load.Config<AstroI18nextConfig>;
-};
-/* c8 ignore stop */
-
-/**
- * Moves the default locale in the first index
- */
-export const moveBaseLanguageToFirstIndex = (
-  supportedLocales: string[],
-  baseLocale: string
-): void => {
-  const baseLocaleIndex = supportedLocales.indexOf(baseLocale);
-  supportedLocales.splice(baseLocaleIndex, 1);
-  supportedLocales.unshift(baseLocale);
-};
 
 /**
  * Interpolates a localized string (loaded with the i18nKey) to a given reference string.
@@ -292,48 +247,4 @@ export const detectLocaleFromPath = (path: string) => {
 
   // return base locale by default
   return i18next.options.supportedLngs[0];
-};
-
-export const deeplyStringifyObject = (obj: object | Array<any>): string => {
-  const isArray = Array.isArray(obj);
-  let str = isArray ? "[" : "{";
-  for (const key in obj) {
-    if (obj[key] === null || obj[key] === undefined) {
-      continue;
-    }
-
-    let value = null;
-
-    // see typeof result: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#description
-    switch (typeof obj[key]) {
-      case "string": {
-        value = `"${obj[key]}"`;
-        break;
-      }
-      case "number":
-      case "boolean": {
-        value = obj[key];
-        break;
-      }
-      case "object": {
-        value = deeplyStringifyObject(obj[key]);
-        break;
-      }
-      case "function": {
-        value = obj[key].toString().replace(/\s+/g, " ");
-        break;
-      }
-      case "symbol": {
-        value = `Symbol("${obj[key].description}")`;
-        break;
-      }
-      /* c8 ignore start */
-      default:
-        break;
-      /* c8 ignore stop */
-    }
-
-    str += isArray ? `${value},` : `"${key}": ${value},`;
-  }
-  return `${str}${isArray ? "]" : "}"}`;
 };


### PR DESCRIPTION
## Issue

When importing `localizeUrl()` into Astro components, the build failed because `@proload` packages were being imported in the same file, and Vite doesn't know how to transpile `@proload`.

```
import { localizeUrl } from 'astro-i18next';
```

<img width="633" alt="image" src="https://user-images.githubusercontent.com/813192/197877074-52af8877-396f-49a2-9209-a0e4856deb24.png">

## Proposal
I'm proposing the following change:

* ```
   import { localizeUrl } from 'astro-i18next/utils';
   ```
* Updating the build script to output a `utils.js` from `src/utils.ts`
* Expose `utils.js` as `astro-i18next/utils` from package.json

## Discussion

I realize I submitted this PR without a corresponding Issue. I'm happy to make that issue, close this PR, and discuss the best solution there before moving forward with a code implementation.
For my project, I needed this change made today, so I figured I'd also submit it back to the project as a proposal.