### PR TITLE
feat: add mobile props to LanguageSelector component

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,21 +350,22 @@ import { Trans } from "astro-i18next/components";
 
 ### LanguageSelector component
 
-Unstyled custom select component to choose amongst supported locales.
+Unstyled custom component to choose amongst supported locales.
 
 ```astro
 ---
 import { LanguageSelector } from "astro-i18next/components";
 ---
 
-<LanguageSelector showFlag={true} class="my-select-class" />
+<LanguageSelector showFlag={true} mobile={true} class="my-select-class" />
 ```
 
 #### LanguageSelector Props
 
-| Prop name | Type (default)     | Description                                               |
-| --------- | ------------------ | --------------------------------------------------------- |
-| showFlag  | ?boolean (`false`) | Choose to display the language emoji before language name |
+| Prop name | Type (default)     | Description                                                    |
+| --------- | ------------------ | -------------------------------------------------------------- |
+| showFlag  | ?boolean (`false`) | Choose to display the language emoji before language name      |
+| mobile    | ?boolean (`false`) | Choose to display the mobile friendly version of the component |
 
 ### HeadHrefLangs component
 

--- a/examples/basics/src/pages/fr/index.astro
+++ b/examples/basics/src/pages/fr/index.astro
@@ -9,7 +9,13 @@ changeLanguage("fr");
 
 <Layout title={t("pageTitle")}>
   <main>
-    <LanguageSelector showFlag={true} class="languages" />
+    <LanguageSelector id="desktop-screen" showFlag={true} class="languages" />
+    <LanguageSelector
+      id="small-screen"
+      showFlag={true}
+      mobile={true}
+      class="languages"
+    />
     <h1>
       <Trans i18nKey="welcome">
         Welcome to <span class="text-gradient">Astro</span>
@@ -75,6 +81,30 @@ changeLanguage("fr");
 
   .languages:is(:hover, :focus-within) {
     border-color: #4f39fa;
+  }
+
+  @media (max-width: 639px) {
+    #desktop-screen {
+      display: none;
+    }
+
+    .languages {
+      display: inline-flex;
+      flex-direction: column;
+    }
+
+    /* CSS rules are automatically scoped by default.
+    We can mix global & scoped CSS rules together for
+    applying CSS styles to children of the component. */
+    .languages :global(ul) {
+      margin: 0.5em 0 0 0.5em;
+    }
+  }
+
+  @media (min-width: 640px) {
+    #small-screen {
+      display: none;
+    }
   }
 
   .text-gradient {

--- a/examples/basics/src/pages/index.astro
+++ b/examples/basics/src/pages/index.astro
@@ -9,7 +9,13 @@ changeLanguage("en");
 
 <Layout title={t("pageTitle")}>
   <main>
-    <LanguageSelector showFlag={true} class="languages" />
+    <LanguageSelector id="desktop-screen" showFlag={true} class="languages" />
+    <LanguageSelector
+      id="small-screen"
+      showFlag={true}
+      mobile={true}
+      class="languages"
+    />
     <h1>
       <Trans i18nKey="welcome">
         Welcome to <span class="text-gradient">Astro</span>
@@ -75,6 +81,30 @@ changeLanguage("en");
 
   .languages:is(:hover, :focus-within) {
     border-color: #4f39fa;
+  }
+
+  @media (max-width: 639px) {
+    #desktop-screen {
+      display: none;
+    }
+
+    .languages {
+      display: inline-flex;
+      flex-direction: column;
+    }
+
+    /* CSS rules are automatically scoped by default.
+    We can mix global & scoped CSS rules together for
+    applying CSS styles to children of the component. */
+    .languages :global(ul) {
+      margin: 0.5em 0 0 0.5em;
+    }
+  }
+
+  @media (min-width: 640px) {
+    #small-screen {
+      display: none;
+    }
   }
 
   .text-gradient {

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -47,9 +47,9 @@ const getLabel = (supportedLanguage: string) => {
       </button>
       <ul id="list" class="hide">
         {supportedLanguages
-          .filter((supportedLanguage: string) => {
-            if (supportedLanguage !== currentLanguage) return supportedLanguage;
-          })
+          .filter(
+            (supportedLanguage: string) => supportedLanguage !== currentLanguage
+          )
           .map((supportedLanguage: string) => {
             return (
               <li class="item">

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -6,6 +6,7 @@ import ISO6991 from "iso-639-1";
 
 export interface Props extends astroHTML.JSX.SelectHTMLAttributes {
   showFlag?: boolean;
+  mobile?: boolean;
 }
 
 const supportedLanguages = i18next.languages;
@@ -13,22 +14,106 @@ const currentLanguage = i18next.language;
 
 const { pathname } = Astro.url;
 
-const { showFlag = false, ...attributes } = Astro.props;
+const { showFlag = false, mobile = false, ...attributes } = Astro.props;
+
+const getValue = (supportedLanguage: string) => {
+  return localizePath(pathname, supportedLanguage);
+};
+
+const getLabel = (supportedLanguage: string) => {
+  const flag = showFlag ? localeEmoji(supportedLanguage) + " " : "";
+  const nativeName = ISO6991.getNativeName(supportedLanguage);
+  return flag + nativeName;
+};
 ---
 
-<select onchange="location = this.value;" {...attributes}>
-  {
-    supportedLanguages.map((supportedLanguage: string) => {
-      let value = localizePath(pathname, supportedLanguage);
-      const flag = showFlag ? localeEmoji(supportedLanguage) + " " : "";
-      const nativeName = ISO6991.getNativeName(supportedLanguage);
-      const label = flag + nativeName;
+{
+  mobile ? (
+    <div {...attributes}>
+      <button
+        class="current-language"
+        onclick="document.getElementById('list').classList.toggle('hide')"
+      >
+        {getLabel(currentLanguage)}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
+          viewBox="0 0 24 24"
+          class="icon chevron"
+        >
+          <path d="M12,16c-0.3,0-0.5-0.1-0.7-0.3l-6-6c-0.4-0.4-0.4-1,0-1.4s1-0.4,1.4,0l5.3,5.3l5.3-5.3c0.4-0.4,1-0.4,1.4,0s0.4,1,0,1.4l-6,6C12.5,15.9,12.3,16,12,16z" />
+        </svg>
+      </button>
+      <ul id="list" class="hide">
+        {supportedLanguages
+          .filter((supportedLanguage: string) => {
+            if (supportedLanguage !== currentLanguage) return supportedLanguage;
+          })
+          .map((supportedLanguage: string) => {
+            return (
+              <li class="item">
+                <button
+                  onclick="location = this.value;"
+                  value={getValue(supportedLanguage)}
+                >
+                  {getLabel(supportedLanguage)}
+                </button>
+              </li>
+            );
+          })}
+      </ul>
+    </div>
+  ) : (
+    <select onchange="location = this.value;" {...attributes}>
+      {supportedLanguages.map((supportedLanguage: string) => {
+        let value = getValue(supportedLanguage);
+        const label = getLabel(supportedLanguage);
 
-      return (
-        <option value={value} selected={supportedLanguage === currentLanguage}>
-          {label}
-        </option>
-      );
-    })
+        return (
+          <option
+            value={value}
+            selected={supportedLanguage === currentLanguage}
+          >
+            {label}
+          </option>
+        );
+      })}
+    </select>
+  )
+}
+
+<style>
+  .hide {
+    display: none;
   }
-</select>
+
+  button.current-language {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+  }
+
+  button svg {
+    width: 1em;
+    margin-left: 0.25em;
+  }
+
+  /* Unset button style */
+  button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+  }
+
+  /* Unset ul style */
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
# Describe your changes

The LanguageSelector component is lacking a mobile friendly display.
I added a mobile props to the component.
The mobile friendly display is made of html button elements.

Please include a summary of the changes and the related issue.

- Updated the component code in `src/components/LanguageSelector.astro`
- Updated the example in `examples/basics`
- Updated the documentation

Fixes #(issue)

[issue 104](https://github.com/yassinedoghri/astro-i18next/issues/104)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [x] I have updated the docs
