### PR TITLE
feat: allow astro versions greater than 1.0.0 as peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://astro-i18next.yassinedoghri.com/",
   "peerDependencies": {
-    "astro": "^1.0.0"
+    "astro": ">=1.0.0"
   },
   "dependencies": {
     "@proload/core": "^0.3.3",


### PR DESCRIPTION
# Describe your changes

Update peer dependencies to allow astro versions greater than 1.0.0. Astro 2.0 launch event on Jan. 24 (https://twitter.com/astrodotbuild/status/1615401112672284672) so 2.0 will be incoming shortly.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [ ] I have updated the docs
