### PR TITLE
docs(readme): fix typo in localizePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ src
 
 > **Note**
 >
-> The [localizedPath](#localizepath-function) and
+> The [localizePath](#localizepath-function) and
 > [localizeUrl](#localizeurl-function) utility functions will retrieve the
 > correct route based on your mappings.
 


### PR DESCRIPTION
# Changes

Fixes typo: `localizedPath` => `localizePath`

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [x] I have updated the docs
