### PR TITLE
feat: make base path for i18next resources configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ your config!
 | namespaces           | `string` or `string[]` ('translation')       | String or array of namespaces to load.                                                                                         |
 | defaultNamespace     | `string` (translation')                      | Default namespace used if not passed to the translation function.                                                              |
 | load                 | `Array<"server" or "client">` (`["server"]`) | Load i18next on server side only, client side only or both.                                                                    |
-| basePath             | `?string`                                    | Set base path for i18next resources. Defaults to `/locales`.
+| resourcesBasePath    | `?string`                                    | Set base path for i18next resources. Defaults to `/locales`.                                                                   |
 | i18nextServer        | `?InitOptions`                               | The i18next server side configuration. See [i18next's documentation](https://www.i18next.com/overview/configuration-options).  |
 | i18nextServerPlugins | `?{[key: string]: string}` (`{}`)            | Set i18next server side plugins. See [available plugins](https://www.i18next.com/overview/plugins-and-utils).                  |
 | i18nextClient        | `?InitOptions`                               | The i18next client side configuration . See [i18next's documentation](https://www.i18next.com/overview/configuration-options). |

--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ your config!
 | namespaces           | `string` or `string[]` ('translation')       | String or array of namespaces to load.                                                                                         |
 | defaultNamespace     | `string` (translation')                      | Default namespace used if not passed to the translation function.                                                              |
 | load                 | `Array<"server" or "client">` (`["server"]`) | Load i18next on server side only, client side only or both.                                                                    |
+| basePath             | `?string`                                    | Set base path for i18next resources. Defaults to `/locales`.
 | i18nextServer        | `?InitOptions`                               | The i18next server side configuration. See [i18next's documentation](https://www.i18next.com/overview/configuration-options).  |
 | i18nextServerPlugins | `?{[key: string]: string}` (`{}`)            | Set i18next server side plugins. See [available plugins](https://www.i18next.com/overview/plugins-and-utils).                  |
 | i18nextClient        | `?InitOptions`                               | The i18next client side configuration . See [i18next's documentation](https://www.i18next.com/overview/configuration-options). |

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export const AstroI18next: AstroI18nextGlobal = {
     flatRoutes: {},
     showDefaultLocale: false,
     trailingSlash: "ignore",
-    basePath: "/locales",
+    resourcesBasePath: "/locales",
   },
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export const AstroI18next: AstroI18nextGlobal = {
     flatRoutes: {},
     showDefaultLocale: false,
     trailingSlash: "ignore",
+    basePath: "/locales",
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export default (options?: AstroI18nextOptions): AstroIntegration => {
             initImmediate: false,
             backend: {
               loadPath: resolve(
-                config.publicDir.pathname + "/locales/{{lng}}/{{ns}}.json"
+                config.publicDir.pathname + `/${astroI18nextConfig.basePath}/{{lng}}/{{ns}}.json`
               ),
             },
             ...astroI18nextConfig.i18nextServer,
@@ -120,7 +120,7 @@ export default (options?: AstroI18nextOptions): AstroIntegration => {
               caches: [],
             },
             backend: {
-              loadPath: "/locales/{{lng}}/{{ns}}.json",
+              loadPath: `${astroI18nextConfig.basePath}/{{lng}}/{{ns}}.json`,
             },
             ...astroI18nextConfig.i18nextClient,
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export default (options?: AstroI18nextOptions): AstroIntegration => {
             initImmediate: false,
             backend: {
               loadPath: resolve(
-                config.publicDir.pathname + `/${astroI18nextConfig.basePath}/{{lng}}/{{ns}}.json`
+                `${config.publicDir.pathname}/${astroI18nextConfig.resourcesBasePath}/{{lng}}/{{ns}}.json`
               ),
             },
             ...astroI18nextConfig.i18nextServer,
@@ -120,7 +120,7 @@ export default (options?: AstroI18nextOptions): AstroIntegration => {
               caches: [],
             },
             backend: {
-              loadPath: `${astroI18nextConfig.basePath}/{{lng}}/{{ns}}.json`,
+              loadPath: `${astroI18nextConfig.resourcesBasePath}/{{lng}}/{{ns}}.json`,
             },
             ...astroI18nextConfig.i18nextClient,
           };

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,13 @@ export interface AstroI18nextConfig {
   load?: ("server" | "client")[];
 
   /**
+   * Set base path for i18next resources.
+   *
+   * @default ["/locales"]
+   */
+  basePath?: string;
+
+  /**
    * i18next server side config. See https://www.i18next.com/overview/configuration-options
    */
   i18nextServer?: InitOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,7 +62,7 @@ export interface AstroI18nextConfig {
    *
    * @default ["/locales"]
    */
-  basePath?: string;
+  resourcesBasePath?: string;
 
   /**
    * i18next server side config. See https://www.i18next.com/overview/configuration-options


### PR DESCRIPTION
# Describe your changes

This PR makes the base path for i18next resources within Astro's `/public` folder configurable. At the moment the base path is hardcoded to `/locales`. 

Why?

If you want to slowly migrate a project to astro and just proxy certain routes to the new project, it might be that `/locales` endpoint is already taken and cannot be proxied to the astro project. So you might want to come up with a different path for the i18next resources.


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [x] I have updated the docs
