### PR TITLE
feat: Added x-default hreflang tag for HeadHrefLangs component

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,22 +270,22 @@ src
      defaultLocale: "en",
      locales: ["en", "fr", "es"],
      routes: {
-      fr: {
-        "about": "a-propos",
-        "contact-us": "contactez-nous",
-        "products": {
-          "index": "produits",
-          "categories": "categories",
-        }
-      }
-      es: {
-        "about": "a-proposito",
-        "contact-us": "contactenos",
-        "products": {
-          "index": "productos",
-          "categories": "categorias",
-        }
-      }
+       fr: {
+         about: "a-propos",
+         "contact-us": "contactez-nous",
+         products: {
+           index: "produits",
+           categories: "categories",
+         },
+       },
+       es: {
+         about: "a-proposito",
+         "contact-us": "contactenos",
+         products: {
+           index: "productos",
+           categories: "categorias",
+         },
+       },
      },
    };
    ```

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ src
      defaultLocale: "en",
      locales: ["en", "fr", "es"],
      routes: {
+   <<<<<<< HEAD
        fr: {
          about: "a-propos",
          "contact-us": "contactez-nous",
@@ -286,6 +287,24 @@ src
            categories: "categorias",
          },
        },
+   =======
+      fr: {
+        "about": "a-propos",
+        "contact-us": "contactez-nous",
+        "products": {
+          "index": "produits",
+          "categories": "categories",
+        }
+      },
+      es: {
+        "about": "a-proposito",
+        "contact-us": "contactenos",
+        "products": {
+          "index": "productos",
+          "categories": "categorias",
+        }
+      }
+   >>>>>>> 6cb1a984e3df170a0901e17a4dcc2e9b9ab92076
      },
    };
    ```
@@ -417,6 +436,11 @@ For example, if you are on the `/about` page and support 3 locales (`en`, `fr`,
 `es`) with `en` being the default locale, this will render:
 
 ```html
+<link
+  rel="alternate"
+  hreflang="x-default"
+  href="https://www.example.com/about/"
+/>
 <link rel="alternate" hreflang="en" href="https://www.example.com/about/" />
 <link rel="alternate" hreflang="fr" href="https://www.example.com/fr/about/" />
 <link rel="alternate" hreflang="es" href="https://www.example.com/es/about/" />

--- a/src/components/HeadHrefLangs.astro
+++ b/src/components/HeadHrefLangs.astro
@@ -1,11 +1,18 @@
 ---
 import i18next from "i18next";
-import { localizeUrl } from "../..";
+import { localizeUrl, AstroI18next } from "../..";
 
 const supportedLanguages = i18next.languages;
+const defaultLanguage = AstroI18next.config.defaultLocale;
 const currentUrl = Astro.url.href;
 ---
 
+<Fragment>
+  <link
+  rel="alternate"
+  hreflang="x-default"
+  href={localizeUrl(currentUrl, defaultLanguage)}
+  />
 {
   supportedLanguages.map((supportedLanguage) => (
     <link
@@ -15,3 +22,4 @@ const currentUrl = Astro.url.href;
     />
   ))
 }
+</Fragment>


### PR DESCRIPTION
# Describe your changes

I noticed that the HeadHrefLangs component in the astro-i18next package does not include the hreflang='x-default' tag. I added the hreflang='x-default' tag to the HeadHrefLangs component.

As a result of adding the hreflang='x-default' tag, I ran an audit using SEO Minion's Hreflang Checker before and after. The audit showed a difference in results.

![hreflang_x-default](https://user-images.githubusercontent.com/64678612/233771907-06ef43fe-1cab-4a14-908b-6e3d4e22c805.jpg)

Fixes #158

## Checklist

- [x] I have performed a self-review of my code
- [x] I have added thorough tests
- [x] I have updated the docs
