### PR TITLE
fix: Conditionally disable 'missing translation key' warning when fallbackLng is false

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,12 @@ export const interpolate = (
   const localizedString = t(i18nKey, { ns: namespace });
 
   if (localizedString === i18nKey) {
-    console.warn(`WARNING(astro-i18next): missing translation key ${i18nKey}.`);
+    const disabledFallback = i18next.options?.fallbackLng === false;
+    // When fallbackLng is set to false, the key is the fallback
+    // so it's expected that the key and localizedString will match
+    if (!disabledFallback) {
+      console.warn(`WARNING(astro-i18next): missing translation key ${i18nKey}.`);
+    }
     return referenceString;
   }
 


### PR DESCRIPTION
# Describe your changes

This is one idea to fix #164  

This PR supports 'key as fallback' option in i18next: https://www.i18next.com/principles/fallback#key-fallback

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [ ] I have updated the docs
