### PR TITLE
fix: Update LanguageSelector.astro as value must be omitted for boolean attributes in html tags

### DIFF
--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -39,8 +39,12 @@ const { showFlag = false, languageMapping, ...attributes } = Astro.props;
 
       const label = flag + nativeName;
 
+      let selectedAttr = {};
+      if (supportedLanguage === currentLanguage)
+        selectedAttr = { ...selectedAttr, selected: ''};
+
       return (
-        <option value={value} selected={supportedLanguage === currentLanguage}>
+        <option value={value} {...selectedAttr}>
           {label}
         </option>
       );


### PR DESCRIPTION
    <select class="language-selector"…>  
      👎 <option value="/" selected='true'> English </option>       👈 Change from this  
      👍 <option value="/" selected> English </option>              👈 to this  

**[According HTML5 spec on boolean attributes](https://www.w3.org/TR/2008/WD-html5-20080610/semantics.html#boolean)**  
If the attribute is present, **its value must either be the empty string or a value** that is a case-insensitive match for the attribute's canonical name, with no leading or trailing whitespace.  
  
# Describe your changes  
  
The code create a single **selected** attribute instead of a **selected='true'** as required by the html5 spec.  
An empty attribute object is first created.  
It is populated with the selected attribute if needed, using js spread syntax.  
Finally the attribute object is injected in the option tag.  
 
# Fixes

Warnings with html syntax checkers. 

## Checklist

- [x ] I have performed a self-review of my code
- [ ] I have added thorough tests
- [ ] I have updated the docs
