### PR TITLE
fix: type in ts5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./components": "./src/components/index.ts"
   },
   "typesVersions": {


### PR DESCRIPTION
# Describe your changes

```
There are types at '/node_modules/astro-i18next/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'astro-i18next' library may need to update its package.json or typings.ts(7016)
```

Fixes #(issue)

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have added thorough tests
- [ ] I have updated the docs
